### PR TITLE
Fixing plugin-transform-flow-strip-types requirement

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,4 @@
 module.exports = {
-  'presets': ['module:metro-react-native-babel-preset'],
+  presets: ['module:metro-react-native-babel-preset'],
+  plugins: [['@babel/plugin-transform-flow-strip-types', { allowDeclareFields: true }]],
 };

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"test": "jest"
 	},
 	"dependencies": {
+		"@babel/plugin-transform-flow-strip-types": "^7.10.4",
 		"@reduxjs/toolkit": "^1.0.4",
 		"@ungap/url-search-params": "^0.1.2",
 		"@youi/react-native-youi": "5.15.0",


### PR DESCRIPTION
This PR fixes this error while running the app:

```
 BUNDLE  [youi, prod] ./index.youi.js ░░░░░░░░░░░░░░░░ 0.0% (0/1)::1 - - [02/Jul/2020:18:45:25 +0000] "GET /index.youi.bundle?platform=youi&dev=false&hot=false&minify=false HTTP/1.1" 500 - "-" "Auryn (unknown version) CFNetwork/1126 Darwin/19.5.0 (x86_64)"
error: bundling failed: SyntaxError: /Auryn/src/screens/video.tsx: The 'declare' modifier is only allowed when the 'allowDeclareFields' option of @babel/plugin-transform-flow-strip-types or @babel/preset-flow is enabled.
  24 | 
  25 | class VideoScreenComponent extends React.Component<VideoProps> {
> 26 |   declare context: VideoContextType;
     |   ^
  27 | 
  28 |   static contextType = VideoContext;
  29 | 
    at File.buildCodeFrameError (/Auryn/node_modules/@babel/core/lib/transformation/file/file.js:259:12)
    at NodePath.buildCodeFrameError (/Auryn/node_modules/@babel/traverse/lib/path/index.js:144:21)
    at /Auryn/node_modules/@babel/plugin-transform-flow-strip-types/lib/index.js:96:27
    at Array.forEach (<anonymous>)
    at PluginPass.Class (/Auryn/node_modules/@babel/plugin-transform-flow-strip-types/lib/index.js:89:31)
    at newFn (/Auryn/node_modules/@babel/traverse/lib/visitors.js:179:21)
    at NodePath._call (/Auryn/node_modules/@babel/traverse/lib/path/context.js:55:20)
    at NodePath.call (/Auryn/node_modules/@babel/traverse/lib/path/context.js:42:17)
    at NodePath.visit (/Auryn/node_modules/@babel/traverse/lib/path/context.js:90:31)
```